### PR TITLE
feat(ci): add ci to validate Rust with Cargo

### DIFF
--- a/.github/workflows/validate-rust.yml
+++ b/.github/workflows/validate-rust.yml
@@ -1,0 +1,49 @@
+name: Rust validation with Cargo
+# For an example usage, see the events-protobuf repo's CI.
+
+on:
+  workflow_call:
+    inputs:
+      toolchain:
+        description: "Rust toolchain to use"
+        required: false
+        type: string
+        default: "stable"
+      install-protoc:
+        required: false
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Beep Protobuf lib
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Protoc
+        if: ${{ inputs.install-protoc }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.cargo/bin:$PATH"
+          rustup update ${{ inputs.toolchain }} && rustup default ${{ inputs.toolchain }}
+
+      - name: Clippy (lint)
+        run: cargo clippy --verbose
+
+      - name: Test
+        run: cargo test --verbose


### PR DESCRIPTION
This CI validates Rust code with Cargo clippy and Cargo test, with an optional Protoc installation.

I couldn't find a better way than to make the Protoc installation an option of this reusable Cargo CI, due to how GH Actions work.