### PR TITLE
fix: update Trivy vulnerability scanner to use Docker run command

### DIFF
--- a/.github/workflows/build-push-main.yml
+++ b/.github/workflows/build-push-main.yml
@@ -47,16 +47,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            ghcr.io/aquasecurity/trivy:0.70.0 image \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --vuln-type os,library \
-            --severity CRITICAL,HIGH \
-            --format table \
-            "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
 
       - name: Push Docker image
         run: |

--- a/.github/workflows/build-push-main.yml
+++ b/.github/workflows/build-push-main.yml
@@ -47,14 +47,16 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.70.0
-        with:
-          image-ref: "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            ghcr.io/aquasecurity/trivy:0.70.0 image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --vuln-type os,library \
+            --severity CRITICAL,HIGH \
+            --format table \
+            "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
 
       - name: Push Docker image
         run: |

--- a/.github/workflows/build-push-tag.yml
+++ b/.github/workflows/build-push-tag.yml
@@ -48,16 +48,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            ghcr.io/aquasecurity/trivy:0.70.0 image \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --vuln-type os,library \
-            --severity CRITICAL,HIGH \
-            --format table \
-            "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
 
       - name: Push Docker image
         run: |

--- a/.github/workflows/build-push-tag.yml
+++ b/.github/workflows/build-push-tag.yml
@@ -48,14 +48,16 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.70.0
-        with:
-          image-ref: "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            ghcr.io/aquasecurity/trivy:0.70.0 image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --vuln-type os,library \
+            --severity CRITICAL,HIGH \
+            --format table \
+            "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
 
       - name: Push Docker image
         run: |


### PR DESCRIPTION
GitHub Action is not able to found `aquasecurity/trivy-action@0.70.0` image : https://github.com/beep-industries/communities/actions/runs/24983694119/job/73151654648

So here I use the Trivy Docker image from the official GitHub repo : `ghcr.io/aquasecurity/trivy:0.70.0`
